### PR TITLE
fix migration Version20200607062919

### DIFF
--- a/src/Migrations/Version20200607062919.php
+++ b/src/Migrations/Version20200607062919.php
@@ -25,9 +25,9 @@ final class Version20200607062919 extends AbstractMigration
         // $this->addSql("UPDATE xenoblade_extraskills as extraskill SET esid = extraskill.id");
         // $this->addSql('ALTER TABLE xenoblade_extraskills MODIFY id INT UNSIGNED NOT NULL');
         // $this->addSql('ALTER TABLE xenoblade_extraskills DROP PRIMARY KEY');
-        $this->addSql('ALTER TABLE xenoblade_extraskills ADD PRIMARY KEY (esid)');
+        $this->addSql('ALTER TABLE xenoblade_extraskills ADD PRIMARY KEY (esid), CHANGE esid esid INT AUTO_INCREMENT NOT NULL');
         // $this->addSql('ALTER TABLE xenoblade_extraskills DROP column id');
-        $this->addSql('ALTER TABLE xenoblade_extraskills CHANGE esid esid INT AUTO_INCREMENT NOT NULL');
+
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
Die Migration Version20200607062919 funktionierte unter Umständen nicht, da in der Datenbank alle Einträge unter `esid` den Wert `0` haben, was eine Umwandlung zum `PRIMARY KEY` aussschließt.
Das update von `esid` auf `PRIMARY KEY` und `AUTO_INCREMENT` muss daher gleichzeitig erfolgen.