### PR TITLE
Benutze 'raw format' für Harmoniegewinn

### DIFF
--- a/src/Views/missions.html.twig
+++ b/src/Views/missions.html.twig
@@ -70,7 +70,7 @@
                     { 'missionItemRelations': mission.itemRelations }
                 ))}}
             </td>
-            <td style="text-align:center">{{ mission.harmonychange }} {% if not mission.harmonychange is empty %}*{% endif %}</td>
+            <td style="text-align:center">{{ mission.harmonychange | raw }} {% if not mission.harmonychange is empty %}*{% endif %}</td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
Harmoniegewinn kann einige Formatierungen wie `<br>` enthalten, daher `raw`-Format.