### PR TITLE
'DoctrineMigrations'-Pfad

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,6 +1,8 @@
 doctrine_migrations:
     migrations_paths:
         'App\Migrations': 'src/Migrations'
+        # path for version 2
+        'DoctrineMigrations': 'src/Migrations'
 
     storage:
         table_storage:


### PR DESCRIPTION
In Version 2.2 des DoctrineMigrationsBundle muss der Pfad 'DoctrineMigrations' gesetzt sein.
Den Pfad doppelt anzugeben sollte zu keinen Kollisionen führen.