### PR TITLE
Stelle aktuelle Seite vornan im <title>-Tag

### DIFF
--- a/src/Views/_layout.html.twig
+++ b/src/Views/_layout.html.twig
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" media="all" href="{{ asset('css/jquery-ui-1.10.3.custom.min.css') }}" />
     <link href="{{ asset('favicon.ico') }}" rel="shortcut icon" type="image/x-icon" />
     {% block head %}{% endblock %}
-    <title>Xenoblade.org | {% block title %}Start{% endblock %}</title>
+    <title>{% block title %}Startseite{% endblock %} | Xenoblade.org </title>
 </head>
 <body>
 <div id="page">


### PR DESCRIPTION
Für Nutzer ist es günstiger, wenn der Seitentitel mit einem aussagekräftigen Text beginnt, da in Tabs oder Lesezeichen meist nur der Anfang lesbar ist.
So kann leichter zwischen den Tabs unterschieden werden.